### PR TITLE
Switch db.js from ES Module to CommonJS

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,53 @@
+// src/app/page.tsx
+'use client'; // Mark as a Client Component
+import { useState } from 'react';
+import styles from '../styles/Chat.module.css';
+
+export default function Home() {
+  const [messages, setMessages] = useState<{ role: string; content: string }[]>([]);
+  const [input, setInput] = useState('');
+
+  const handleSend = async () => {
+    if (input.trim()) {
+      const userMessage = { role: 'user', content: input };
+      setMessages((prev: { role: string; content: string }[]) => [...prev, userMessage]);
+
+      // Send user input to the API route
+      const response = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: input }),
+      });
+
+      const data = await response.json();
+      const botMessage = { role: 'bot', content: data.reply };
+      setMessages((prev: { role: string; content: string }[]) => [...prev, botMessage]);
+
+      setInput('');
+    }
+  };
+
+  return (
+    <div className={styles.chatContainer}>
+      <div className={styles.messages}>
+        {messages.map((msg: { role: string; content: string }, index: number) => (
+          <div key={index} className={msg.role === 'user' ? styles.userMessage : styles.botMessage}>
+            {msg.content}
+          </div>
+        ))}
+      </div>
+      <div className={styles.inputContainer}>
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          className={styles.input}
+          placeholder="Type your message..."
+        />
+        <button onClick={handleSend} className={styles.button}>
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -1,0 +1,11 @@
+// src/lib/db.js
+const mysql = require('mysql2/promise');
+
+const db = mysql.createPool({
+  host: process.env.DB_HOST,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+});
+
+module.exports = db;


### PR DESCRIPTION
This PR updates db.js to use CommonJS syntax instead of ES Module (import/export). The change ensures compatibility with Node.js when importing the MySQL database connection. Key updates include:

Replacing import with require for mysql2/promise
Using module.exports instead of export default
This resolves issues related to module parsing errors when using import and export.